### PR TITLE
Rename `getAccessTree()` to `getHierarchy()` in `ItemsStorageInterface` implementations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,3 @@
 | Is bugfix?    | ✔️/❌
 | New feature?  | ✔️/❌
 | Breaks BC?    | ✔️/❌
-| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Enh #53: Use snake case for item attribute names (ease migration from Yii 2) (@arogachev)
 - Enh #45: Decrease size for string columns from 128 to 126 for PostgreSQL optimization (@arogachev)
 - Chg #58: Sync with changes in db package (simplify quoting and recursive query) (@arogachev)
+- Chg #: Rename `getAccessTree()` to `getHierarchy()` in `ItemsStorageInterface` implentations (@arogachev)
 
 ## 1.0.0 April 20, 2023
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The package provides [Yii Database](https://github.com/yiisoft/db) storage for
 
 ## Requirements
 
-- PHP 8.0 or higher.
+- PHP 8.1 or higher.
 - `PDO` PHP extension.
 - One of the following drivers:
   - [SQLite](https://github.com/yiisoft/db-sqlite) (minimal required version is 3.8.3)

--- a/src/ItemTreeTraversal/CteItemTreeTraversal.php
+++ b/src/ItemTreeTraversal/CteItemTreeTraversal.php
@@ -65,7 +65,7 @@ abstract class CteItemTreeTraversal implements ItemTreeTraversalInterface
             ->select(['name', new Expression($this->getEmptyChildrenExpression())])
             ->from($this->tableName)
             ->where(['name' => $name])
-            ->union($cteSelectRelationQuery, all: true);
+            ->union($cteSelectRelationQuery);
         $outerQuery = $baseOuterQuery
             ->withQuery($cteSelectItemQuery, 'parent_of(child_name, children)', recursive: true)
             ->from('parent_of')
@@ -168,7 +168,7 @@ abstract class CteItemTreeTraversal implements ItemTreeTraversalInterface
             ->select('name')
             ->from($this->tableName)
             ->where(['name' => $names])
-            ->union($cteSelectRelationQuery, all: true);
+            ->union($cteSelectRelationQuery);
         $outerQuery = $baseOuterQuery
             ->withQuery($cteSelectItemQuery, "$cteName($cteParameterName)", recursive: true)
             ->from($cteName)

--- a/src/ItemTreeTraversal/CteItemTreeTraversal.php
+++ b/src/ItemTreeTraversal/CteItemTreeTraversal.php
@@ -61,11 +61,13 @@ abstract class CteItemTreeTraversal implements ItemTreeTraversalInterface
             ->innerJoin('parent_of', [
                 'item_child_recursive.child' => new Expression('{{parent_of}}.[[child_name]]'),
             ]);
+        /** @infection-ignore-all FalseValuem, union */
         $cteSelectItemQuery = (new Query($this->database))
             ->select(['name', new Expression($this->getEmptyChildrenExpression())])
             ->from($this->tableName)
             ->where(['name' => $name])
-            ->union($cteSelectRelationQuery);
+            ->union($cteSelectRelationQuery, all: true);
+        /** @infection-ignore-all FalseValue, recursive */
         $outerQuery = $baseOuterQuery
             ->withQuery($cteSelectItemQuery, 'parent_of(child_name, children)', recursive: true)
             ->from('parent_of')
@@ -164,11 +166,13 @@ abstract class CteItemTreeTraversal implements ItemTreeTraversalInterface
                     "{{{$cteName}}}.[[$cteParameterName]]",
                 ),
             ]);
+        /** @infection-ignore-all FalseValue, union */
         $cteSelectItemQuery = (new Query($this->database))
             ->select('name')
             ->from($this->tableName)
             ->where(['name' => $names])
-            ->union($cteSelectRelationQuery);
+            ->union($cteSelectRelationQuery, all: true);
+        /** @infection-ignore-all FalseValue, recursive */
         $outerQuery = $baseOuterQuery
             ->withQuery($cteSelectItemQuery, "$cteName($cteParameterName)", recursive: true)
             ->from($cteName)

--- a/src/ItemTreeTraversal/CteItemTreeTraversal.php
+++ b/src/ItemTreeTraversal/CteItemTreeTraversal.php
@@ -20,7 +20,7 @@ use Yiisoft\Rbac\Item;
  * @internal
  *
  * @psalm-import-type RawItem from ItemsStorage
- * @psalm-import-type AccessTree from ItemTreeTraversalInterface
+ * @psalm-import-type Hierarchy from ItemTreeTraversalInterface
  */
 abstract class CteItemTreeTraversal implements ItemTreeTraversalInterface
 {
@@ -52,7 +52,7 @@ abstract class CteItemTreeTraversal implements ItemTreeTraversalInterface
         return $this->getRowsCommand($name, baseOuterQuery: $baseOuterQuery)->queryAll();
     }
 
-    public function getAccessTree(string $name): array
+    public function getHierarchy(string $name): array
     {
         $baseOuterQuery = (new Query($this->database))->select(['item.*', 'parent_of.children']);
         $cteSelectRelationQuery = (new Query($this->database))
@@ -74,7 +74,7 @@ abstract class CteItemTreeTraversal implements ItemTreeTraversalInterface
                 ['item.name' => new Expression('{{parent_of}}.[[child_name]]')],
             );
 
-        /** @psalm-var AccessTree */
+        /** @psalm-var Hierarchy */
         return $outerQuery->all();
     }
 

--- a/src/ItemTreeTraversal/ItemTreeTraversalInterface.php
+++ b/src/ItemTreeTraversal/ItemTreeTraversalInterface.php
@@ -13,7 +13,7 @@ use Yiisoft\Rbac\Item;
  *
  * @internal
  *
- * @psalm-type AccessTree = non-empty-list<array{
+ * @psalm-type Hierarchy = non-empty-list<array{
  *     type: Item::TYPE_*,
  *     name: string,
  *     description: string|null,
@@ -43,9 +43,9 @@ interface ItemTreeTraversalInterface
      *
      * @param string $name The child name.
      *
-     * @psalm-return AccessTree
+     * @psalm-return Hierarchy
      */
-    public function getAccessTree(string $name): array;
+    public function getHierarchy(string $name): array;
 
     /**
      * Get all children rows for an item by the given name.

--- a/src/ItemTreeTraversal/MysqlItemTreeTraversal.php
+++ b/src/ItemTreeTraversal/MysqlItemTreeTraversal.php
@@ -62,7 +62,7 @@ final class MysqlItemTreeTraversal implements ItemTreeTraversalInterface
 
     public function getHierarchy(string $name): array
     {
-        $sql = "SELECT item.*, access_tree_base.children FROM (
+        $sql = "SELECT item.*, hierarchy_base.children FROM (
             SELECT
                 child_name,
                 MIN(TRIM(BOTH '$this->namesSeparator'
@@ -70,10 +70,11 @@ final class MysqlItemTreeTraversal implements ItemTreeTraversalInterface
                 SELECT @r AS child_name, @path := concat(@path, '$this->namesSeparator', @r) as raw_children,
                 (SELECT @r := parent FROM $this->childrenTableName WHERE child = child_name LIMIT 1) AS parent
                 FROM (SELECT @r := :name, @path := '') val, $this->childrenTableName
-            ) raw_access_tree_base
+            ) raw_hierarchy_base
             GROUP BY child_name
-        ) access_tree_base
-        LEFT JOIN $this->tableName AS item ON item.name = access_tree_base.child_name";
+        ) hierarchy_base
+        LEFT JOIN $this->tableName AS item ON item.name = hierarchy_base.child_name
+        WHERE item.name IS NOT NULL";
 
         /** @psalm-var Hierarchy */
         return $this

--- a/src/ItemTreeTraversal/MysqlItemTreeTraversal.php
+++ b/src/ItemTreeTraversal/MysqlItemTreeTraversal.php
@@ -19,7 +19,7 @@ use Yiisoft\Rbac\Item;
  * @internal
  *
  * @psalm-import-type RawItem from ItemsStorage
- * @psalm-import-type AccessTree from ItemTreeTraversalInterface
+ * @psalm-import-type Hierarchy from ItemTreeTraversalInterface
  */
 final class MysqlItemTreeTraversal implements ItemTreeTraversalInterface
 {
@@ -60,7 +60,7 @@ final class MysqlItemTreeTraversal implements ItemTreeTraversalInterface
             ->queryAll();
     }
 
-    public function getAccessTree(string $name): array
+    public function getHierarchy(string $name): array
     {
         $sql = "SELECT item.*, access_tree_base.children FROM (
             SELECT
@@ -75,7 +75,7 @@ final class MysqlItemTreeTraversal implements ItemTreeTraversalInterface
         ) access_tree_base
         LEFT JOIN $this->tableName AS item ON item.name = access_tree_base.child_name";
 
-        /** @psalm-var AccessTree */
+        /** @psalm-var Hierarchy */
         return $this
             ->database
             ->createCommand($sql, [':name' => $name])

--- a/src/ItemsStorage.php
+++ b/src/ItemsStorage.php
@@ -285,12 +285,12 @@ final class ItemsStorage implements ItemsStorageInterface
         return $this->getItemsIndexedByName($rawItems);
     }
 
-    public function getAccessTree(string $name): array
+    public function getHierarchy(string $name): array
     {
         $tree = [];
         $childrenNamesMap = [];
 
-        foreach ($this->getTreeTraversal()->getAccessTree($name) as $data) {
+        foreach ($this->getTreeTraversal()->getHierarchy($name) as $data) {
             $childrenNamesMap[$data['name']] = $data['children'] !== '' && $data['children'] !== null
                 ? explode($this->namesSeparator, $data['children'])
                 : [];

--- a/src/ItemsStorage.php
+++ b/src/ItemsStorage.php
@@ -474,8 +474,6 @@ final class ItemsStorage implements ItemsStorageInterface
     {
         $item = $this
             ->createItemByTypeAndName($rawItem['type'], $rawItem['name'])
-            ->withDescription($rawItem['description'] ?? '')
-            ->withRuleName($rawItem['rule_name'] ?? null)
             ->withCreatedAt((int) $rawItem['created_at'])
             ->withUpdatedAt((int) $rawItem['updated_at']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
